### PR TITLE
Fix button card `TouchEvent` reference for Firefox & Safari

### DIFF
--- a/src/google-button/google-button-card.ts
+++ b/src/google-button/google-button-card.ts
@@ -134,7 +134,12 @@ export class GoogleButtonCard extends LitElement {
     this._cancelPress(); // elimina timer precedente se presente
     this._moved = false;
 
-    if (event instanceof TouchEvent && event.touches.length > 0) {
+    if (
+      // as of 2025, TouchEvent constructor is not available in Firefox and Safari
+      typeof TouchEvent !== 'undefined' &&
+      event instanceof TouchEvent &&
+      event.touches.length > 0
+    ) {
       this._startX = event.touches[0].clientX;
       this._startY = event.touches[0].clientY;
     } else if (event instanceof MouseEvent) {


### PR DESCRIPTION
**Steps to reproduce:**

1. On Lovelace dashboard, add a "Generic" Google Button card with default configurations.
2. Open the dashboard in Firefox or Safari.
3. Attempt to click/tap the card.

**Expected behavior:** Switch toggles or button action works.

**Actual behavior:** Nothing happens. Error in console as described on #1. 

**Cause:** `TouchEvent` constructor is not (yet) available on Firefox and Safari: https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent

**Solution:** Add a null check for `TouchEvent` before trying to access.